### PR TITLE
Playermanager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>net.mattlabs.mauvelist</groupId>
     <artifactId>MauveList</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
 
     <description>
         Greylist plugin for deleting user data files/adding new members

--- a/src/main/java/net/mattlabs/mauvelist/Data.java
+++ b/src/main/java/net/mattlabs/mauvelist/Data.java
@@ -1,10 +1,13 @@
 package net.mattlabs.mauvelist;
 
+import net.mattlabs.mauvelist.util.MauvePlayerData;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 import org.spongepowered.configurate.objectmapping.meta.Setting;
 
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 @ConfigSerializable
 public class Data {
@@ -32,9 +35,9 @@ public class Data {
             "Config version. Do not change this!")
     private int schemaVersion = 0;
 
-    private ArrayList<String> nonMemberList = new ArrayList<>();
+    private Map<UUID, MauvePlayerData> mauvePlayerMap = new HashMap<>();
 
-    public ArrayList<String> getNonMemberList() {
-        return  nonMemberList;
+    public Map<UUID, MauvePlayerData> getMauvePlayerMap() {
+        return mauvePlayerMap;
     }
 }

--- a/src/main/java/net/mattlabs/mauvelist/MauveList.java
+++ b/src/main/java/net/mattlabs/mauvelist/MauveList.java
@@ -83,7 +83,6 @@ public class MauveList extends JavaPlugin {
         
         // Load Player Manager
         playerManager = new PlayerManager();
-        playerManager.loadPlayerData();
 
         // Register Audience (Messages)
         platform = BukkitAudiences.create(this);

--- a/src/main/java/net/mattlabs/mauvelist/listeners/JoinListener.java
+++ b/src/main/java/net/mattlabs/mauvelist/listeners/JoinListener.java
@@ -18,6 +18,7 @@ public class JoinListener implements Listener {
 
         Player player = event.getPlayer();
 
+        // Player is a guest, set spectator and tp to spawn
         if (player.hasPermission("mauvelist.grey")) {
             player.setGameMode(GameMode.SPECTATOR);
             player.teleport(Bukkit.getWorlds().get(0).getSpawnLocation());
@@ -26,7 +27,21 @@ public class JoinListener implements Listener {
                     () -> MauveList.getInstance().getLogger().info(player.getName() + " has logged in as a guest."),
                     20);
 
-            playerManager.addPlayer(player);
+            if (!playerManager.playerExists(player)) playerManager.addPlayer(player);
+        }
+        // Player is a member
+        else {
+            // First join, set to survival, tp to spawn
+            if (playerManager.isNew(player)) {
+                player.setGameMode(GameMode.SURVIVAL);
+                player.teleport(Bukkit.getWorlds().get(0).getSpawnLocation());
+
+                playerManager.setNew(player, false);
+
+                Bukkit.getScheduler().runTaskLater(MauveList.getInstance(),
+                        () -> MauveList.getInstance().getLogger().info(player.getName() + " has logged in as a member for the first time."),
+                        20);
+            }
         }
     }
 }

--- a/src/main/java/net/mattlabs/mauvelist/util/ApplicationManager.java
+++ b/src/main/java/net/mattlabs/mauvelist/util/ApplicationManager.java
@@ -29,6 +29,8 @@ public class ApplicationManager {
     private final Config config = mauveList.getConfigML();
     private final JDA jda = mauveList.getJda();
     private final Logger logger = mauveList.getLogger();
+
+    private final PlayerManager playerManager = mauveList.getPlayerManager();
     private final Map<User, Application> applications = new HashMap<>();
 
     // Add a new Discord user to the applications map
@@ -177,6 +179,8 @@ public class ApplicationManager {
             application.stopTimeout();
             application.setState(Application.State.SUBMITTED);
 
+            playerManager.addPlayer(Bukkit.getOfflinePlayer(application.getUsername()));
+
             logger.info("Application for " + user.getName() + " has been submitted.");
         }
     }
@@ -254,6 +258,9 @@ public class ApplicationManager {
 
             return;
         }
+
+        // Update player data
+        playerManager.setNew(Bukkit.getOfflinePlayer(application.getUsername()), true);
 
         // Update applications channel
         jda.getTextChannelById(config.getApplicationChannel()).sendMessage(messages.applicationAccepted(user, application.getAnswers().get(0), acceptor)).queue();

--- a/src/main/java/net/mattlabs/mauvelist/util/MauvePlayerData.java
+++ b/src/main/java/net/mattlabs/mauvelist/util/MauvePlayerData.java
@@ -1,0 +1,19 @@
+package net.mattlabs.mauvelist.util;
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+
+@ConfigSerializable
+public class MauvePlayerData {
+
+    private boolean isNew = false;
+
+    public MauvePlayerData() {}
+
+    public boolean isNew() {
+        return isNew;
+    }
+
+    public void setNew(boolean isNew) {
+        this.isNew = isNew;
+    }
+}

--- a/src/main/java/net/mattlabs/mauvelist/util/PlayerManager.java
+++ b/src/main/java/net/mattlabs/mauvelist/util/PlayerManager.java
@@ -2,72 +2,35 @@ package net.mattlabs.mauvelist.util;
 
 import net.mattlabs.mauvelist.MauveList;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.LinkedList;
+import java.util.Map;
 import java.util.UUID;
 
-public class PlayerManager implements Runnable{
+/* PlayerManager keeps track of every player that joins the server */
+public class PlayerManager {
 
-    private MauveList mauveList = MauveList.getInstance();
-    private LinkedList<UUID> nonMemberUUID;
-    private LinkedList<String> nonMemberName, nonMemberDate;
+    private final MauveList mauveList = MauveList.getInstance();
+    private final Map<UUID, MauvePlayerData> mauvePlayerMap = mauveList.getData().getMauvePlayerMap();
 
-    public void addPlayer(Player player) {
-        nonMemberName.remove(player.getName());
-        nonMemberName.addFirst(player.getName());
-        if (nonMemberName.size() == 11) nonMemberName.removeLast();
-        nonMemberUUID.remove(player.getUniqueId());
-        nonMemberUUID.addFirst(player.getUniqueId());
-        if (nonMemberUUID.size() == 11) nonMemberUUID.removeLast();
-
-        Date date = new Date(player.getLastLogin());
-        DateFormat dateFormat = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss");
-        nonMemberDate.remove(dateFormat.format(date));
-        nonMemberDate.addFirst(dateFormat.format(date));
-        if (nonMemberDate.size() == 11) nonMemberDate.removeLast();
-
-
-        Bukkit.getServer().getScheduler().runTaskAsynchronously(MauveList.getInstance(), this);
+    public void addPlayer(OfflinePlayer player) {
+        mauvePlayerMap.put(player.getUniqueId(), new MauvePlayerData());
+        save();
     }
 
-    public void loadPlayerData() {
-        nonMemberUUID = new LinkedList<>();
-        nonMemberName = new LinkedList<>();
-        nonMemberDate = new LinkedList<>();
-        ArrayList<String> loadList = mauveList.getData().getNonMemberList();
-        for (String string : loadList) {
-            String[] parts = string.split("\\|");
-            nonMemberUUID.add(UUID.fromString(parts[0]));
-            nonMemberName.add(parts[1]);
-            nonMemberDate.add(parts[2]);
-        }
+    public boolean playerExists(OfflinePlayer player) {
+        return mauvePlayerMap.containsKey(player.getUniqueId());
     }
 
-    public LinkedList<UUID> getNonMemberUUID() {
-        return nonMemberUUID;
+    public boolean isNew(OfflinePlayer player) {
+        return mauvePlayerMap.get(player.getUniqueId()).isNew();
+    }
+    public void setNew(OfflinePlayer player, boolean isNew) {
+        mauvePlayerMap.get(player.getUniqueId()).setNew(isNew);
+        save();
     }
 
-    public LinkedList<String> getNonMemberName() {
-        return nonMemberName;
-    }
-
-    public LinkedList<String> getNonMemberDate() {
-        return nonMemberDate;
-    }
-
-    // Saves data to file asynchronously
-    @Override
-    public void run() {
-        ArrayList<String> saveList = new ArrayList<>();
-        ArrayList<String> actualList = mauveList.getData().getNonMemberList();
-        for (int i = 0; i < nonMemberName.size(); i++) saveList.add(nonMemberUUID.get(i) + "|" + nonMemberName.get(i) + "|" + nonMemberDate.get(i));
-
-        actualList = saveList;
-        mauveList.getConfigurateManager().save("data.conf");
+    private void save() {
+        Bukkit.getScheduler().runTaskAsynchronously(mauveList, () -> mauveList.getConfigurateManager().save("data.conf"));
     }
 }


### PR DESCRIPTION
This revamps the PlayerManager class, which used to exist to track guest players to be added. Now it will create data points on the user. If they join as a guest in Minecraft, they are added. If they submit an application they are added. For now, the only data point helps determine the first join after being accepted so the player can be teleported to spawn and set to survival mode. In the future, this can be used to track number of applications, play status and anything else. 

This also fixes the issue that new members were not being switched to survival gamemode. 